### PR TITLE
Fixed Error with Challenge 2 and Challenge 3 ( Comparing string with number ) 

### DIFF
--- a/ch-2/challengeTwoTest.php
+++ b/ch-2/challengeTwoTest.php
@@ -43,12 +43,13 @@ class challengeTwoTest extends TestCase
       $this->assertArrayHasKey($key, $result['impact']);
       $this->assertArrayHasKey($key, $result['severeImpact']);
     }
-    
+
     $values = valueOnFields($result, $estimate, $challenge);
     foreach ($values as $estimation) {
-      $produced = $estimation[0];
+      $produced = $estimation[2];
       $expected = $estimation[1];
-      $this->assertEquals($produced, $expected); 
+      $this->assertEquals($produced, $expected);
     }
   }
 }
+

--- a/ch-3/challengeThreeTest.php
+++ b/ch-3/challengeThreeTest.php
@@ -46,9 +46,10 @@ class challengeThreeTest extends TestCase
 
     $values = valueOnFields($result, $estimate, $challenge);
     foreach ($values as $estimation) {
-      $produced = $estimation[0];
+      $produced = $estimation[2];
       $expected = $estimation[1];
       $this->assertEquals($produced, $expected);
     }
   }
 }
+


### PR DESCRIPTION
I could not pass the test for challenge two because the values to be compared are incompatible ( string and number). 
Same thing also happens in the test for Challenge 3.
I have fixed the issue.

Here is a sample error message
Error Message: **Failed asserting that 29023241502720.0 matches expected 'severeCasesByRequestedTime'**

**Failed asserting that 236978176.0 matches expected 'casesForICUByRequestedTime'.**
